### PR TITLE
nixpkgs: Bump Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Distributing PDFs will get you sued for lots of money ( https://en.wikipedia.org
 ## Getting Started
 * install [poppler-utils](https://poppler.freedesktop.org/), or more specifically, make sure the pdftocairo binary from poppler-utils is in your `$PATH`
 * git clone this repository
-* run this from cabal `cabal run`
+* run this from cabal `cabal run` (optionally: `nix-shell --run "cabal run"`)
 * point your web browser to `localhost:3000`
 * run repository with nix-shell `nix-shell shell.nix --command "cabal run fermatslastmargin"`
 All of the annotations are saved in a local directory `~/.fermatslastmargin/localuser` and your friend's annotations are saved in `~/.fermatslastmargin/friends/<github_name_of_friend>`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Distributing PDFs will get you sued for lots of money ( https://en.wikipedia.org
 * git clone this repository
 * run this from cabal `cabal run`
 * point your web browser to `localhost:3000`
-
+* run repository with nix-shell `nix-shell shell.nix --command "cabal run fermatslastmargin"`
 All of the annotations are saved in a local directory `~/.fermatslastmargin/localuser` and your friend's annotations are saved in `~/.fermatslastmargin/friends/<github_name_of_friend>`
 
 # Features

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Distributing PDFs will get you sued for lots of money ( https://en.wikipedia.org
 * git clone this repository
 * run this from cabal `cabal run` (optionally: `nix-shell --run "cabal run"`)
 * point your web browser to `localhost:3000`
-* run repository with nix-shell `nix-shell shell.nix --command "cabal run fermatslastmargin"`
 All of the annotations are saved in a local directory `~/.fermatslastmargin/localuser` and your friend's annotations are saved in `~/.fermatslastmargin/friends/<github_name_of_friend>`
 
 # Features

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,7 +7,7 @@ with rec {
       (self: super: super.lib.recursiveUpdate super {
         haskell = super.lib.recursiveUpdate super.haskell {
           packages = super.lib.recursiveUpdate super.haskell.packages {
-            ghc864 = super.haskell.packages.ghc864.override (old: {
+            ghc881 = super.haskell.packages.ghc881.override (old: {
               overrides = super.lib.composeExtensions
                 (old.overrides or (_: _: {}))
                 (hself: hsuper: {
@@ -25,5 +25,5 @@ with rec {
 rec {
   inherit pkgs;
   inherit sources;
-  hsPkgs = pkgs.haskell.packages.ghc864;
+  hsPkgs = pkgs.haskell.packages.ghc881;
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-19.03",
+        "branch": "nixos-20.03",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "27f48796194dacd685019d0d63018b387cd7b112",
-        "sha256": "1lhp3rz8h522j2bs0qswi4w5n7njs9f0fqkbbyd4l8hp4kplarib",
+        "rev": "91cdcf313578e9520bb45cb21e6a9b1773bd656c",
+        "sha256": "133sxph6qzankv5v63v8vlvg9dkbrki3b8xgi5pa88c0njx5x8qp",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/27f48796194dacd685019d0d63018b387cd7b112.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/91cdcf313578e9520bb45cb21e6a9b1773bd656c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -12,6 +12,7 @@ hsPkgs.shellFor {
     stylish-haskell
     ghcid
     cabal-install
+    poppler_utils
   ];
 
   exactDeps = true;


### PR DESCRIPTION
Update the nixpkgs which can be solved version of dependencies and sync version with repo.
- Test nix-build
```
./result/bin/fermatslastmargin                                              
Setting phasers to stun... (port 3000) (ctrl-c to quit)
```
- Test nix-shell
```
nix-shell shell.nix --command "cabal run fermatslastmargin"                 
Up to date
Setting phasers to stun... (port 3000) (ctrl-c to quit)
```